### PR TITLE
Implement a simple resampler working for in_freq / out_freq in range 0.5-1.0

### DIFF
--- a/src/drivers/sound/sound-sdl.c
+++ b/src/drivers/sound/sound-sdl.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <limits.h>
+#include <emscripten.h>
 
 #include <drivers/options.h>
 #include <drivers/sound/sound.h>
@@ -66,6 +67,7 @@ sound_sdl_buf_t *snd_sdl_buf_new (sound_sdl_t *drv, unsigned size)
 	buf->next = NULL;
 
 	buf->idx = 0;
+	buf->d_idx = 0;
 	buf->cnt = 0;
 
 	if (buf->max < size) {
@@ -172,19 +174,10 @@ int snd_sdl_write (sound_drv_t *sdrv, const uint16_t *buf, unsigned cnt)
 }
 
 static
-void snd_sdl_callback (void *user, Uint8 *buf, int cnt)
+void snd_sdl_callback_no_resample (sound_sdl_t *drv, Uint8 *buf, int cnt)
 {
 	int             n;
-	sound_sdl_t     *drv;
 	sound_sdl_buf_t *src;
-
-	drv = user;
-
-	if (drv->head == NULL) {
-		SDL_PauseAudio (1);
-		drv->is_paused = 1;
-		return;
-	}
 
 	while (cnt > 0) {
 		if (drv->head == NULL) {
@@ -222,11 +215,112 @@ void snd_sdl_callback (void *user, Uint8 *buf, int cnt)
 	}
 }
 
+/*
+ * Resampling can handle only input_freq / output_freq in range [0.5 1.0]
+ */
+// lowpass filter cut off, use 0 to remove lowpass filter
+#define CUT_OFF 6000
+
+static
+void sdl_snd_fix_lowpass (sound_sdl_t *drv, int chn, int freq, int srate)
+{
+	unsigned i;
+
+	for (i = 0; i < chn; i++) {
+		snd_iir2_set_lowpass (
+			&drv->sdl_lowpass_iir2[i],
+			freq, srate
+		);
+
+		snd_iir2_reset (&drv->sdl_lowpass_iir2[i]);
+	}
+}
+
+void snd_sdl_callback_resample (sound_sdl_t *drv, uint16_t *dest, int cnt)
+{
+	int             n;
+	sound_sdl_buf_t *src;
+
+	cnt /= 2;
+
+	int feed = 0;
+	int old_cnt = cnt;
+	uint16_t * old_dest = dest;
+
+	for ( ; cnt > 0 ; cnt--) {
+		src = drv->head;
+		sound_sdl_buf_t *old_src = src;
+		if (src->d_idx >= src->cnt/2) {
+
+			drv->head = src->next;
+
+			if (drv->head == NULL) {
+				drv->tail = NULL;
+			}
+
+			src->next = drv->free;
+			drv->free = src;
+
+			src = drv->head;
+
+			if (!src) {
+#if DEBUG_SND_SDL >= 1
+				fprintf (stderr, "snd-sdl: buffer underrun\n");
+#endif
+				emscripten_log(EM_LOG_CONSOLE, "snd-sdl: buffer underrun");
+				memset (dest, 0, cnt*2);
+				return;
+			}
+			src->d_idx = old_src->d_idx - (int)old_src->d_idx;
+		}
+
+		int16_t sample0 = drv->last_sample;
+		int16_t sample1 = *((int16_t*)src->data + (int)src->d_idx);
+		float frac = src->d_idx - (int)src->d_idx;
+		int16_t sample = (1 - frac) * sample0 + frac * sample1;
+
+		// Instead of working on input[iPos], input[iPos+1] we work
+		// on input[ipos-1], input[ipos], it works this way by updating
+		// the last sample only if the next step will cross an integer
+		// boundary.
+		if (src->d_idx + drv->s_ratio - (int)src->d_idx >= 1)
+			drv->last_sample = sample1;
+
+		*dest++ = sample;
+		src->d_idx += drv->s_ratio;
+	}
+#if CUT_OFF
+	// yes, inplace filter work
+	snd_iir2_filter (
+		&drv->sdl_lowpass_iir2[0], old_dest, old_dest,
+		old_cnt, drv->sdrv.channels, drv->sign
+		);
+#endif
+}
+
+void snd_sdl_callback (void *user, Uint8 *buf, int cnt)
+{
+	sound_sdl_t  *drv = user;
+
+	if (drv->head == NULL) {
+		SDL_PauseAudio (1);
+		drv->is_paused = 1;
+		return;
+	}
+
+	if (drv->s_ratio == 1.0) {
+		snd_sdl_callback_no_resample(user, buf, cnt);
+	}
+	else {
+		snd_sdl_callback_resample(user, (uint16_t*)buf, cnt);
+	}
+}
+
 static
 int snd_sdl_set_params (sound_drv_t *sdrv, unsigned chn, unsigned long srate, int sign)
 {
 	sound_sdl_t   *drv;
-	SDL_AudioSpec req;
+	SDL_AudioSpec req, obtained;
 
 	drv = sdrv->ext;
 
@@ -252,7 +346,7 @@ int snd_sdl_set_params (sound_drv_t *sdrv, unsigned chn, unsigned long srate, in
 	req.callback = snd_sdl_callback;
 	req.userdata = drv;
 
-	if (SDL_OpenAudio (&req, NULL) < 0) {
+	if (SDL_OpenAudio (&req, &obtained) < 0) {
 		fprintf (stderr, "snd-sdl: error opening output (%s)\n",
 			SDL_GetError()
 		);
@@ -266,6 +360,13 @@ int snd_sdl_set_params (sound_drv_t *sdrv, unsigned chn, unsigned long srate, in
 
 	drv->sign = 1;
 	drv->big_endian = 0;
+	drv->s_ratio = srate/(float)obtained.freq;
+	fprintf(stderr, "srate: %lu:%d %f\n", srate, obtained.freq, drv->s_ratio);
+	drv->last_sample = 0;
+
+#if CUT_OFF
+	sdl_snd_fix_lowpass(drv, chn, CUT_OFF, obtained.freq);
+#endif
 
 	return (0);
 }

--- a/src/drivers/sound/sound-sdl.h
+++ b/src/drivers/sound/sound-sdl.h
@@ -33,11 +33,14 @@ typedef struct sound_sdl_buf_t {
 	unsigned               cnt;
 	unsigned               max;
 	unsigned char          *data;
+	float                  d_idx;
 } sound_sdl_buf_t;
 
 typedef struct sound_sdl_t {
 	sound_drv_t sdrv;
 
+	// our private lowpass filter
+	sound_iir2_t  sdl_lowpass_iir2[SND_CHN_MAX];
 	char        is_open;
 	char        is_paused;
 
@@ -45,6 +48,10 @@ typedef struct sound_sdl_t {
 	int         big_endian;
 
 	unsigned        buf_cnt;
+
+	// ratio of asked sample rate to obtained sample rate for resampling.
+	float       s_ratio;
+	int16_t     last_sample;
 
 	sound_sdl_buf_t *head;
 	sound_sdl_buf_t *tail;


### PR DESCRIPTION

It use a linear interpolation plus a lowpass filter. This is used by the
macplus emulator with it's 22255 hz frequency which is actually mapped to
32000 hz by the sdl1 emscripten port. It use floating point index in the
input buffer because 22255 = 4451 * 5 and 4451 is prime which make
difficult to implement it through a multi pass insertion decimation.

This applied to Hampa Hug work well but in a browser there is still some
artifact at buffer boundary. It's unclear if it comes from the browser
unable to call enough fast the buffer filler or from the rewrite of the
main emulator loop.